### PR TITLE
Crockford does express a preference when it comes to variable declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,19 @@ var foo = "",
   bar = "",
   quux;
 ```
+Multiple in one go, line ending commas and four spaces indentation: Crockford
+```js
+var foo = "",
+    bar = "",
+    quux;
+```
 Start with comma: npm
 ```js
 var foo = ""
   , bar = ""
   , quux;
 ```
-No expressed opinion: Google, Crockford
+No expressed opinion: Google
 
 Braces
 ------
@@ -242,5 +248,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-


### PR DESCRIPTION
Hi Otto,

I was pleased to see this initiative and would like to contribute to it.

Crockford does express a preference when it comes to variable declarations.

Basically the same style as Idiomatic and jQuery prefer but with 4 spaces instead of 2.

``` js
var foo = "",
    bar = "",
    quux;
```

source:
http://javascript.crockford.com/code.html,
http://www.jslint.com/
##### On a other note

Crockford also prefers to give every variable line a comment but I don't know whether it is more appropriate to add this to the command or the variable declaration section
